### PR TITLE
feat: Support for request verification

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,10 @@ objects against the schemas.</p>
 <dd></dd>
 <dt><del><a href="#extractSqsRecords">extractSqsRecords()</a></del></dt>
 <dd></dd>
+<dt><a href="#Security.">Security.(allowedPermissions, actualPermissions)</a> ⇒ <code>boolean</code></dt>
+<dd><p>Checks to see if any of the allowed permissions are present in the actual permissions,
+using globbing expansion</p>
+</dd>
 </dl>
 
 ## Typedefs
@@ -46,9 +50,15 @@ objects against the schemas.</p>
 <dt><a href="#QueueRecord">QueueRecord</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#Handler">Handler</a> ⇒ <code>Promise.&lt;Response&gt;</code></dt>
-<dd><p>Function for handling a routes inside Frankin / Content Lake services</p>
+<dd><p>Function for handling a routes inside Franklin / Content Lake services</p>
 </dd>
 <dt><a href="#SecretConfig">SecretConfig</a> : <code><a href="#AwsConfig">AwsConfig</a></code> | <code>SecretConfigExt</code></dt>
+<dd></dd>
+<dt><a href="#AuthenticationRequirement">AuthenticationRequirement</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#TokenRequest">TokenRequest</a> : <code>Object</code></dt>
+<dd></dd>
+<dt><a href="#TokenPayload">TokenPayload</a> : <code>Object</code></dt>
 <dd></dd>
 </dl>
 
@@ -97,6 +107,19 @@ as specified in https://wiki.corp.adobe.com/display/WEM/Ingestor+API+Contract
 ***Deprecated***
 
 **Kind**: global function  
+<a name="Security."></a>
+
+## Security.(allowedPermissions, actualPermissions) ⇒ <code>boolean</code>
+Checks to see if any of the allowed permissions are present in the actual permissions,
+using globbing expansion
+
+**Kind**: global function  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| allowedPermissions | <code>Array.&lt;string&gt;</code> | the list of permissions which are allowed |
+| actualPermissions | <code>Array.&lt;string&gt;</code> | the actual permissions from the request |
+
 <a name="BlobStorageConfig"></a>
 
 ## BlobStorageConfig : <code>Object</code>
@@ -200,7 +223,7 @@ as specified in https://wiki.corp.adobe.com/display/WEM/Ingestor+API+Contract
 <a name="Handler"></a>
 
 ## Handler ⇒ <code>Promise.&lt;Response&gt;</code>
-Function for handling a routes inside Frankin / Content Lake services
+Function for handling a routes inside Franklin / Content Lake services
 
 **Kind**: global typedef  
 **Returns**: <code>Promise.&lt;Response&gt;</code> - the response from the request  
@@ -220,4 +243,47 @@ Function for handling a routes inside Frankin / Content Lake services
 | Name | Type |
 | --- | --- |
 | [client] | <code>SecretsManagerClient</code> | 
+| application | <code>string</code> | 
+| [companyId] | <code>string</code> | 
+| [scope] | <code>string</code> | 
+
+<a name="AuthenticationRequirement"></a>
+
+## AuthenticationRequirement : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| [allowedRoles] | <code>Array.&lt;string&gt;</code> | 
+| [allowedPermissions] | <code>Array.&lt;string&gt;</code> | 
+
+<a name="TokenRequest"></a>
+
+## TokenRequest : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| spaceId | <code>string</code> | the space for which the token will be generated |
+| roleKeys | <code>Array.&lt;string&gt;</code> | the role keys for which the token should be generated |
+| generator | <code>string</code> | provides attribution for the key in the description |
+| [expiresInMinutes] | <code>number</code> | the number of minutes before the token expires (or 14 days) |
+
+<a name="TokenPayload"></a>
+
+## TokenPayload : <code>Object</code>
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| permissions | <code>Array.&lt;string&gt;</code> | the permissions granted to this token |
+| roles | <code>Array.&lt;string&gt;</code> | the permissions granted to this token |
+| sub | <code>string</code> | the subject (or identifier) for this token |
+| tenantId | <code>string</code> | the primary tenant for the token |
+| [tenantIds] | <code>Array.&lt;string&gt;</code> | the optional list of additional  allowed tenants for the token |
+| type | <code>string</code> | the type of the token |
+| exp | <code>number</code> | the timestamp at which the token will expire |
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,8 @@ using globbing expansion</p>
 <dd></dd>
 <dt><a href="#QueueRecord">QueueRecord</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="#SecurityConfig">SecurityConfig</a></dt>
+<dd></dd>
 <dt><a href="#Handler">Handler</a> ⇒ <code>Promise.&lt;Response&gt;</code></dt>
 <dd><p>Function for handling a routes inside Franklin / Content Lake services</p>
 </dd>
@@ -220,6 +222,18 @@ using globbing expansion
 | messageAttributes | <code>Record.&lt;string, any&gt;</code> | 
 | eventSource | <code>string</code> | 
 
+<a name="SecurityConfig"></a>
+
+## SecurityConfig
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| authRequired; | <code>boolean</code> | 
+| [allowedRoles] | <code>Array.&lt;string&gt;</code> | 
+| [allowedPermissions] | <code>Array.&lt;string&gt;</code> | 
+
 <a name="Handler"></a>
 
 ## Handler ⇒ <code>Promise.&lt;Response&gt;</code>
@@ -230,9 +244,8 @@ Function for handling a routes inside Franklin / Content Lake services
 
 | Param | Type | Description |
 | --- | --- | --- |
-| req | <code>Request</code> | the request |
-| context | <code>UniversalContext</code> | the context of the request |
 | params | <code>Record.&lt;string, string&gt;</code> | the parameters parsed from the request |
+| info | <code>Object</code> | the   additional request information |
 
 <a name="SecretConfig"></a>
 

--- a/it/secret.test.js
+++ b/it/secret.test.js
@@ -27,7 +27,7 @@ dotenv.config();
 const SLOW_TEST_TIMEOUT = 5000;
 
 describe('Secrets Manager Integration Tests', async () => {
-  const defaultConfig = { scope: 'test', application: 'commons-it' };
+  const defaultConfig = { scope: 'test', application: 'commons-secrets-it' };
   const helper = new ContextHelper(process);
   it('fails on non-existing secret', async () => {
     const mgr = new SecretsManager({
@@ -85,7 +85,7 @@ describe('Secrets Manager Integration Tests', async () => {
       .then((res) => {
         Promise.all(
           res.SecretList.filter(
-            (secret) => secret.Name.startsWith('test') || secret.Name.startsWith('it'),
+            (secret) => secret.Name.startsWith('test/shared/commons-secrets-it/'),
           ).map((secret) => secretManager.send(
             new DeleteSecretCommand({
               SecretId: secret.Name,

--- a/it/secret.test.js
+++ b/it/secret.test.js
@@ -19,7 +19,7 @@ import {
   DeleteSecretCommand,
   ListSecretsCommand,
 } from '@aws-sdk/client-secrets-manager';
-import { extractAwsConfig } from '../src/context.js';
+import { ContextHelper } from '../src/context.js';
 import { SecretsManager } from '../src/secret.js';
 
 dotenv.config();
@@ -27,9 +27,13 @@ dotenv.config();
 const SLOW_TEST_TIMEOUT = 5000;
 
 describe('Secrets Manager Integration Tests', async () => {
-  const extractor = 'it';
+  const defaultConfig = { scope: 'test', application: 'commons-it' };
+  const helper = new ContextHelper(process);
   it('fails on non-existing secret', async () => {
-    const mgr = new SecretsManager(extractor, extractAwsConfig(process));
+    const mgr = new SecretsManager({
+      ...defaultConfig,
+      ...helper.extractAwsConfig(),
+    });
     let caught;
     try {
       await mgr.getSecret('not-a-secret');
@@ -41,7 +45,10 @@ describe('Secrets Manager Integration Tests', async () => {
 
   it('can create, get and delete secret', async () => {
     const secretId = randomUUID();
-    const mgr = new SecretsManager(extractor, extractAwsConfig(process));
+    const mgr = new SecretsManager({
+      ...defaultConfig,
+      ...helper.extractAwsConfig(),
+    });
     let caught;
     try {
       await mgr.getSecret(secretId);
@@ -64,7 +71,10 @@ describe('Secrets Manager Integration Tests', async () => {
   }).timeout(SLOW_TEST_TIMEOUT);
 
   after(async () => {
-    const secretManager = new SecretsManagerClient(extractAwsConfig(process));
+    const secretManager = new SecretsManagerClient({
+      ...defaultConfig,
+      ...helper.extractAwsConfig(),
+    });
     await secretManager
       .send(
         new ListSecretsCommand({

--- a/it/security.test.js
+++ b/it/security.test.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import * as dotenv from 'dotenv';
+import { Security } from '../src/security.js';
+
+dotenv.config();
+
+const SLOW_TEST_TIMEOUT = 5000;
+const spaceId = process.env.SPACE_ID;
+
+function createRequest(token) {
+  return new Request('http://localhost/', {
+    headers: {
+      'x-space-id': spaceId,
+      authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+describe('Security Integration Tests', async () => {
+  const security = new Security({ ...process, scope: 'test' });
+  it('can generate and authorize tokens', async () => {
+    const token = await security.generateToken({
+      generator: 'Commons Security IT',
+      spaceId,
+      roleKeys: ['Admin'],
+    });
+    assert.ok(token);
+    await security.authorize(createRequest(token));
+  }).timeout(SLOW_TEST_TIMEOUT);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/content-lake-commons",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/content-lake-commons",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.299.0",
@@ -17,6 +17,8 @@
         "clone": "^2.1.2",
         "fetch-retry": "^5.0.4",
         "jsonschema": "^1.4.1",
+        "jsonwebtoken": "^9.0.0",
+        "minimatch": "^9.0.1",
         "node-fetch": "^3.3.1",
         "routington": "^1.0.3"
       },
@@ -1786,6 +1788,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.41.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
@@ -1807,6 +1821,18 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2893,8 +2919,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -2955,6 +2980,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/c8": {
       "version": "7.13.0",
@@ -3853,6 +3883,14 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -4311,6 +4349,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -4346,6 +4396,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -4948,6 +5010,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -5985,6 +6059,21 @@
         "node": "*"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/junit-report-builder": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-3.0.1.tgz",
@@ -6005,6 +6094,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -6348,8 +6456,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -6968,15 +7075,25 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/minimist": {
@@ -7171,8 +7288,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -11750,8 +11866,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -12069,7 +12184,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12111,7 +12225,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -12801,6 +12914,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/test-value": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
@@ -13336,8 +13461,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.2.2",
@@ -14938,6 +15062,17 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "@eslint/js": {
@@ -14955,6 +15090,17 @@
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.5"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "@humanwhocodes/module-importer": {
@@ -15766,8 +15912,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "before-after-hook": {
       "version": "2.2.3",
@@ -15822,6 +15967,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "c8": {
       "version": "7.13.0",
@@ -16516,6 +16666,14 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -16744,6 +16902,17 @@
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "eslint-config-airbnb-base": {
@@ -16863,6 +17032,15 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "semver": {
@@ -17320,6 +17498,17 @@
         "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -18067,6 +18256,17 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      }
+    },
     "junit-report-builder": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-3.0.1.tgz",
@@ -18084,6 +18284,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -18323,8 +18542,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -18794,12 +19012,21 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
     },
     "minimist": {
@@ -18947,8 +19174,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
       "version": "3.3.3",
@@ -22088,8 +22314,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex-test": {
       "version": "1.0.0",
@@ -22307,7 +22532,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -22316,7 +22540,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -22861,6 +23084,17 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "test-value": {
@@ -23285,8 +23519,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "clone": "^2.1.2",
     "fetch-retry": "^5.0.4",
     "jsonschema": "^1.4.1",
+    "jsonwebtoken": "^9.0.0",
+    "minimatch": "^9.0.1",
     "node-fetch": "^3.3.1",
     "routington": "^1.0.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -20,5 +20,6 @@ export * from './rest-error.js';
 export * from './router.js';
 export * from './schema-validator.js';
 export * from './secret.js';
+export * from './security.js';
 export { CloudSearchIndexStorage } from './cloud-search-index-storage.js';
 export * as mocks from './mocks/index.js';

--- a/src/mocks/index.js
+++ b/src/mocks/index.js
@@ -11,5 +11,6 @@
  */
 
 export * from './local-search-index-storage.js';
+export * from './local-key-security.js';
 export * from './queue.js';
 export * from './secrets.js';

--- a/src/mocks/local-key-security.js
+++ b/src/mocks/local-key-security.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import jwt from 'jsonwebtoken';
+import { generateKeyPairSync, randomUUID } from 'crypto';
+import { Security } from '../security.js';
+import { MockSecretsManager } from './secrets.js';
+
+export class LocalKeySecurity extends Security {
+  /**
+   * @type {Array<string>}
+   */
+  additionalTenantIds;
+
+  #privateKey;
+
+  /**
+   * @type {Record<string,Array<string>>}
+   */
+  roleToPermissions = {};
+
+  constructor() {
+    const secretsManager = new MockSecretsManager();
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    secretsManager.putSecret('public-key', publicKey);
+    super({
+      secretsManager,
+    });
+    this.#privateKey = privateKey;
+  }
+
+  /**
+   * Generates a server to server token with the specified settings
+   * @param {import('../security.js').TokenRequest} request
+   * @returns {Promise<string>}
+   */
+  async generateToken(request) {
+    const permissions = new Set();
+    request.roleKeys
+      .forEach((role) => this.roleToPermissions[role]
+        ?.forEach((permission) => permissions.add(permission)));
+    return jwt.sign(
+      {
+        permissions: Array.from(permissions),
+        roles: request.roleKeys,
+        tenantId: request.spaceId,
+        tenantIds: this.additionalTenantIds,
+      },
+      this.#privateKey,
+      { expiresIn: (request.expiresInMinutes || 120) * 60, subject: randomUUID(), algorithm: 'RS256' },
+    );
+  }
+}

--- a/src/mocks/secrets.js
+++ b/src/mocks/secrets.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-export class MockSecretsStore {
+export class MockSecretsManager {
   secrets = {};
 
   reset() {

--- a/src/router.js
+++ b/src/router.js
@@ -11,13 +11,21 @@
  */
 import routington from 'routington';
 import { RestError } from './rest-error.js';
+import { ContextHelper } from './context.js';
 
 /**
- * Function for handling a routes inside Frankin / Content Lake services
+ * @typedef SecurityConfig
+ * @property {boolean} authRequired;
+ * @property {Array<string>} [allowedRoles]
+ * @property {Array<string>} [allowedPermissions]
+ */
+
+/**
+ * Function for handling a routes inside Franklin / Content Lake services
  * @callback Handler
- * @param {Request} req the request
- * @param {UniversalContext} context the context of the request
  * @param {Record<string,string>} params the parameters parsed from the request
+ * @param {{request:Request,context:import('./context.js').UniversalishContext}} info the
+ *   additional request information
  * @returns {Promise<Response>} the response from the request
  */
 
@@ -25,25 +33,33 @@ export class Router {
   methods = {};
 
   /**
+   * @type {import('./security.js').Security | undefined}
+   */
+  #security;
+
+  /**
    *
    * @param {string} method
    * @param {string} path
    * @param {Handler} handler
+   * @param {SecurityConfig} [securityConfig]
    */
-  addRoute(method, path, handler) {
+  addRoute(method, path, handler, securityConfig) {
     if (!this.methods[method]) {
       this.methods[method] = routington();
     }
     this.methods[method].define(path)[0].handler = handler;
+    this.methods[method].define(path)[0].securityConfig = securityConfig;
   }
 
   /**
    *
    * @param {string} path
    * @param {Handler} handler
+   * @param {SecurityConfig} [securityConfig]
    */
-  delete(path, handler) {
-    this.addRoute('DELETE', path, handler);
+  delete(path, handler, securityConfig) {
+    this.addRoute('DELETE', path, handler, securityConfig);
     return this;
   }
 
@@ -51,9 +67,10 @@ export class Router {
    *
    * @param {string} path
    * @param {Handler} handler
+   * @param {SecurityConfig} [securityConfig]
    */
-  get(path, handler) {
-    this.addRoute('GET', path, handler);
+  get(path, handler, securityConfig) {
+    this.addRoute('GET', path, handler, securityConfig);
     return this;
   }
 
@@ -61,9 +78,10 @@ export class Router {
    *
    * @param {string} path
    * @param {Handler} handler
+   * @param {SecurityConfig} [securityConfig]
    */
-  post(path, handler) {
-    this.addRoute('POST', path, handler);
+  post(path, handler, securityConfig) {
+    this.addRoute('POST', path, handler, securityConfig);
     return this;
   }
 
@@ -71,20 +89,31 @@ export class Router {
    *
    * @param {string} path
    * @param {Handler} handler
+   * @param {SecurityConfig} [securityConfig]
    */
-  put(path, handler) {
-    this.addRoute('PUT', path, handler);
+  put(path, handler, securityConfig) {
+    this.addRoute('PUT', path, handler, securityConfig);
+    return this;
+  }
+
+  /**
+   *
+   * @param {import('./security.js').Security} security
+   */
+  withSecurity(security) {
+    this.#security = security;
     return this;
   }
 
   /**
    * Handles the specified request
    * @param {Request} request
-   * @param {UniveralContext} context
+   * @param {import('./context.js').UniversalishContext} context
    * @returns {Promise<Response>}
    */
   async handle(request, context) {
-    const log = context.log || console;
+    const helper = new ContextHelper(context);
+    const log = helper.getLog();
     const { method } = request;
     let suffix = context.pathInfo?.suffix;
     if (!suffix || suffix === '') {
@@ -95,7 +124,17 @@ export class Router {
       const match = this.methods[method].match(suffix);
       if (match && match.node.handler) {
         try {
-          return await match.node.handler(request, context, match.param);
+          const { handler, securityConfig } = match.node;
+          if (securityConfig && securityConfig.authRequired) {
+            if (!this.#security) {
+              throw new Error(
+                'Misconfiguration, security is required for this route, but no security handler registered',
+              );
+            }
+            await this.#security.authorize(request);
+            await this.#security.authenticate(request, securityConfig);
+          }
+          return await handler(match.param, { request, context });
         } catch (err) {
           log.warn('Caught exception from handler', {
             method,

--- a/src/secret.js
+++ b/src/secret.js
@@ -22,23 +22,31 @@ import {
 /**
  * @typedef SecretConfigExt
  * @property {SecretsManagerClient} [client]
+ * @property {string} application
+ * @property {string} [companyId]
+ * @property {string} [scope]
  *
  * @typedef {import('./common-typedefs.js').AwsConfig & SecretConfigExt} SecretConfig
  */
 
 export class SecretsManager {
+  #application;
+
   #client;
 
-  #namespace;
+  #group;
+
+  #scope;
 
   /**
-   * Creates a Configuration Manager
-   * @param {string} namespace the namespace for the secret
-   * @param {SecretConfig} config the configuration
+   * Creates a Secrets Manager
+   * @param {SecretConfig} [config] the configuration
    */
-  constructor(namespace, config) {
+  constructor(config) {
     this.#client = config.client || new SecretsManagerClient(config);
-    this.#namespace = namespace;
+    this.#application = config.application;
+    this.#group = config.companyId || 'shared';
+    this.#scope = config.scope || 'prod';
   }
 
   /**
@@ -47,7 +55,7 @@ export class SecretsManager {
    * @returns {string} the full key for accessing the secret
    */
   #makeKey(id) {
-    return `${this.#namespace}-${id}`;
+    return [this.#scope, this.#group, this.#application, id].join('/');
   }
 
   /**

--- a/src/security.js
+++ b/src/security.js
@@ -98,8 +98,9 @@ export class Security {
    * @param {AuthenticationRequirement} [authentication] the requirements
    *    for authentication to succeed
    * @param {Request} req the request
+   * @returns {Promise<void>}
    */
-  authenticate(req, authentication) {
+  async authenticate(req, authentication) {
     const token = this.#getToken(req);
     const spaceId = this.#getRequiredHeader(req, 'x-space-id');
     const payload = jwt.decode(token);

--- a/src/security.js
+++ b/src/security.js
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import jwt from 'jsonwebtoken';
+import { minimatch } from 'minimatch';
+import fetch from 'node-fetch';
+import { ContextHelper } from './context.js';
+import { RestError } from './rest-error.js';
+import { SecretsManager } from './secret.js';
+
+const BEARER_OFFSET = 7;
+
+/**
+ * @typedef {Object} AuthenticationRequirement
+ * @property {Array<string>} [allowedRoles]
+ * @property {Array<string>} [allowedPermissions]
+ */
+
+/**
+ * @typedef {Object} TokenRequest
+ * @property {string} spaceId the space for which the token will be generated
+ * @property {Array<string>} roleKeys the role keys for which the token should be generated
+ * @property {string} generator provides attribution for the key in the description
+ * @property {number} [expiresInMinutes] the number of minutes before the token expires (or 14 days)
+ */
+
+/**
+ * @typedef {Object} TokenPayload
+ * @property {Array<string>} permissions the permissions granted to this token
+ * @property {Array<string>} roles the permissions granted to this token
+ * @property {string} sub the subject (or identifier) for this token
+ * @property {string} tenantId the primary tenant for the token
+ * @property {Array<string>} [tenantIds] the optional list of additional
+ *  allowed tenants for the token
+ * @property {string} type the type of the token
+ * @property {number} exp the timestamp at which the token will expire
+ */
+
+export class Security {
+  /**
+   * Checks to see if any of the allowed permissions are present in the actual permissions,
+   * using globbing expansion
+   * @param {Array<string>} allowedPermissions the list of permissions which are allowed
+   * @param {Array<string>} actualPermissions the actual permissions from the request
+   * @returns {boolean}
+   */
+  static #hasPermissions(allowedPermissions, actualPermissions) {
+    return allowedPermissions
+      .some((required) => actualPermissions.some((granted) => minimatch(required, granted)));
+  }
+
+  /**
+   * @type {string}
+   */
+  #apiHost;
+
+  #certificate;
+
+  /**
+   * @type {import('./common-typedefs.js').Logger}
+   */
+  #log;
+
+  /**
+   * Maps the role names to role IDs
+   * @type {Record<string,string>}
+   */
+  #roles;
+
+  /**
+   * @type {SecretsManager}
+   */
+  #secretsManager;
+
+  constructor(context) {
+    const helper = new ContextHelper(context);
+    this.#apiHost = helper.getEnv().SECURITY_API_HOST || 'https://api.frontegg.com';
+    this.#log = helper.getLog();
+    this.#secretsManager = context.secretsManager
+      || new SecretsManager({
+        ...helper.extractAwsConfig(),
+        application: 'frontegg',
+        scope: context.scope,
+      });
+  }
+
+  /**
+   * Authenticates that the request is allowed to continue based on
+   * the authentication requirements
+   * @param {AuthenticationRequirement} [authentication] the requirements
+   *    for authentication to succeed
+   * @param {Request} req the request
+   */
+  authenticate(req, authentication) {
+    const token = this.#getToken(req);
+    const spaceId = this.#getRequiredHeader(req, 'x-space-id');
+    const payload = jwt.decode(token);
+
+    // first validate that the tenant is correct
+    if (
+      payload.tenantId !== spaceId
+      && !(payload.tenantIds || []).includes(spaceId)
+    ) {
+      this.#log.debug(
+        `Mismatched spaceId, expected ${spaceId}, found ${payload.tenantId}`,
+      );
+      throw new RestError(403);
+    }
+    if (
+      authentication?.allowedRoles
+      && authentication.allowedRoles.length > 0
+    ) {
+      if (
+        !authentication.allowedRoles.some((role) => (payload.roles || []).includes(role))
+      ) {
+        this.#log.debug('Payload did not contain allowed roles', {
+          allowedRoles: authentication.allowedRoles,
+          roles: payload.roles,
+        });
+        throw new RestError(403);
+      }
+    }
+
+    if (
+      authentication?.allowedPermissions
+      && authentication.allowedPermissions.length > 0
+    ) {
+      const permissions = payload.permissions || [];
+      if (
+        !Security.#hasPermissions(
+          authentication.allowedPermissions,
+          permissions,
+        )
+      ) {
+        this.#log.debug('Payload did not contain allowed roles', {
+          allowedRoles: authentication.allowedRoles,
+          roles: payload.roles,
+        });
+        throw new RestError(403);
+      }
+    }
+  }
+
+  /**
+   * Verifies that the request has an authorization header and that the value
+   * of that header is a valid JWT token signed with the Private key associated
+   * with the provided Public key.
+   * @param {Request} req the request to authorize
+   * @returns {Promise<void>} resolves if the request is authorized
+   */
+  async authorize(req) {
+    this.#getRequiredHeader(req, 'x-space-id');
+    const token = this.#getToken(req);
+    await this.#verifyToken(token);
+  }
+
+  /**
+   * Generates a server to server token with the specified settings
+   * @param {TokenRequest} request
+   * @returns {Promise<string>}
+   */
+  async generateToken(request) {
+    const authToken = await this.#getAuthToken();
+    if (!this.#roles) {
+      this.#roles = await this.#getRoles(authToken);
+    }
+    const roleIds = request.roleKeys.map((k) => this.#roles[k]);
+
+    return this.#generateAccessToken(
+      authToken,
+      request.spaceId,
+      request.generator,
+      roleIds,
+      request.expiresInMinutes || 20160,
+    );
+  }
+
+  /**
+   *
+   * @param {string} authToken
+   * @param {string} spaceId
+   * @param {string} generator
+   * @param {Array<string>} roleIds
+   * @param {number | undefined} expiresInMinutes
+   */
+  async #generateAccessToken(
+    authToken,
+    spaceId,
+    generator,
+    roleIds,
+    expiresInMinutes,
+  ) {
+    const res = await fetch(
+      `${this.#apiHost}/identity/resources/tenants/access-tokens/v1`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: `Bearer ${authToken}`,
+          'frontegg-tenant-id': spaceId,
+        },
+        method: 'POST',
+        body: JSON.stringify({
+          expiresInMinutes,
+          roleIds,
+          description: `Auto-created for ${generator} at ${new Date().toISOString()}`,
+        }),
+      },
+    );
+    if (!res.ok) {
+      await this.#logErrorResponse('Failed to generate access token', res);
+      throw new RestError(500, 'Failed to generate access token, check logs');
+    }
+    const body = await res.json();
+    return body.secret;
+  }
+
+  /**
+   * @returns {Promise<string>}
+   */
+  async #getAuthToken() {
+    const secrets = await this.#secretsManager.getSecret('api-access');
+    const res = await fetch(`${this.#apiHost}/auth/vendor`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: secrets,
+    });
+    if (!res.ok) {
+      await this.#logErrorResponse('Failed to get auth token', res);
+      throw new RestError(500, 'Failed to get auth token, check logs');
+    }
+    const body = await res.json();
+    return body.token;
+  }
+
+  /**
+   * Gets the specified header, throwing a BadRequest header if the header
+   * is not found.
+   * @param {Request} req
+   * @param {string} headerName
+   * @returns {string} the header value
+   */
+  #getRequiredHeader(req, headerName) {
+    const value = req.headers.get(headerName);
+    if (!value) {
+      this.#log.debug(`Missing header [${headerName}]`);
+      throw new RestError(400, `Missing header [${headerName}]`);
+    }
+    return value;
+  }
+
+  /**
+   * Retrieves the role key > role id mapping
+   * @param {string} authToken
+   * @returns {Promise<Record<string,string>>}
+   */
+  async #getRoles(authToken) {
+    const res = await fetch(`${this.#apiHost}/identity/resources/roles/v1`, {
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: `Bearer ${authToken}`,
+      },
+    });
+    if (!res.ok) {
+      await this.#logErrorResponse('Failed to get roles', res);
+      throw new RestError(500, 'Failed to get roles, check logs');
+    }
+    const body = await res.json();
+    const roles = {};
+    body.forEach((role) => {
+      roles[role.key] = role.id;
+    });
+    return roles;
+  }
+
+  /**
+   * Gets the token from the request
+   * @param {Request} req
+   * @returns {string}
+   */
+  #getToken(req) {
+    const authorization = this.#getRequiredHeader(req, 'authorization');
+    if (!authorization.toLowerCase().startsWith('bearer ')) {
+      this.#log.debug('Invalid or missing authorization header');
+      throw new RestError(401);
+    }
+    return authorization.substring(BEARER_OFFSET);
+  }
+
+  /**
+   * @param {string} message
+   * @param {Response} res
+   */
+  async #logErrorResponse(message, res) {
+    let body = 'Unable to read body';
+    try {
+      body = await res.text();
+    } catch (err) {
+      this.#log.error('Failed to read body', err);
+    }
+    this.#log.error(message, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers),
+      url: res.url,
+      body,
+    });
+  }
+
+  /**
+   * Verifies the specified token
+   * @param {string} token the token string to verify
+   * @returns {Promise<any>} the resolve JWT payload
+   */
+  async #verifyToken(token) {
+    if (!this.#certificate) {
+      this.#certificate = await this.#secretsManager.getSecret('public-key');
+    }
+    return new Promise((resolve, reject) => {
+      jwt.verify(token, this.#certificate, (err, user) => {
+        if (err) {
+          this.#log.warn('Failed to verify authorization', err);
+          reject(new RestError(401));
+        }
+        resolve(user);
+      });
+    });
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,6 +24,7 @@ import {
   Router,
   SchemaValidator,
   SecretsManager,
+  Security,
 } from '../src/index.js';
 
 describe('Index Tests', () => {
@@ -47,7 +48,7 @@ describe('Index Tests', () => {
     assert.ok(mocks);
     assert.ok(mocks.LocalSearchIndexStorage);
     assert.ok(mocks.MockQueueClient);
-    assert.ok(mocks.MockSecretsStore);
+    assert.ok(mocks.MockSecretsManager);
   });
 
   it('export QueueClient is present', async () => {
@@ -68,5 +69,9 @@ describe('Index Tests', () => {
 
   it('export SecretsManager is present', async () => {
     assert.ok(SecretsManager);
+  });
+
+  it('export Security is present', async () => {
+    assert.ok(Security);
   });
 });

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -26,27 +26,61 @@ describe('SecretsManager Unit Tests', () => {
 
   it('can get secret', async () => {
     const mockClient = new MockAwsClient();
-    const manager = new SecretsManager('test-ns', { client: mockClient });
+    const manager = new SecretsManager({
+      client: mockClient,
+      application: 'test-app',
+    });
     mockClient.resp = {
       SecretString: 'test-secret',
     };
     const resp = await manager.getSecret('test-id');
     assert.strictEqual(resp, 'test-secret');
-    assert.strictEqual(mockClient.req.input.SecretId, 'test-ns-test-id');
+    assert.strictEqual(
+      mockClient.req.input.SecretId,
+      'prod/shared/test-app/test-id',
+    );
   });
 
   it('can put secret', async () => {
     const mockClient = new MockAwsClient();
-    const manager = new SecretsManager('test-ns', { client: mockClient });
+    const manager = new SecretsManager({
+      client: mockClient,
+      application: 'test-app',
+    });
     await manager.putSecret('test-id', 'test-secret');
-    assert.strictEqual(mockClient.req.input.SecretId, 'test-ns-test-id');
+    assert.strictEqual(
+      mockClient.req.input.SecretId,
+      'prod/shared/test-app/test-id',
+    );
+    assert.strictEqual(mockClient.req.input.SecretString, 'test-secret');
+  });
+
+  it('can change app and scope', async () => {
+    const mockClient = new MockAwsClient();
+    const manager = new SecretsManager({
+      client: mockClient,
+      application: 'test-app2',
+      companyId: 'test-company',
+      scope: 'test',
+    });
+    await manager.putSecret('test-id', 'test-secret');
+    assert.strictEqual(
+      mockClient.req.input.SecretId,
+      'test/test-company/test-app2/test-id',
+    );
     assert.strictEqual(mockClient.req.input.SecretString, 'test-secret');
   });
 
   it('can delete secret', async () => {
     const mockClient = new MockAwsClient();
-    const manager = new SecretsManager('test-ns', { client: mockClient });
+    const manager = new SecretsManager({
+      client: mockClient,
+      application: 'test-app',
+    });
     await manager.deleteSecret('test-id');
-    assert.strictEqual(mockClient.req.input.SecretId, 'test-ns-test-id');
+    assert.strictEqual(
+      mockClient.req.input.SecretId,
+      'prod/shared/test-app/test-id',
+    );
   });
 });

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import assert from 'assert';
+import { LocalKeySecurity } from '../src/mocks/local-key-security.js';
+
+function createRequest(spaceId, token) {
+  return new Request('http://localhost/', {
+    headers: {
+      'x-space-id': spaceId,
+      authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+/**
+ * Asserts that the call fails with an exception with the supplied status code
+ * @param {number} expectedStatus
+ * @param {():Promise<void>} fn
+ */
+async function assertFailsWithStatus(expectedStatus, fn) {
+  let caught;
+  try {
+    await fn();
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught);
+  assert.equal(caught.status, expectedStatus);
+}
+
+describe('Security Unit Tests', () => {
+  describe('authorization', () => {
+    let token;
+    const security = new LocalKeySecurity();
+    before(async () => {
+      token = await security.generateToken({
+        spaceId: 'test-space',
+        generator: 'unittest',
+        roleKeys: ['test-role'],
+      });
+      assert.ok(token);
+    });
+
+    it('rejects missing authorization header', async () => {
+      const request = new Request('http://localhost/', {
+        headers: {
+          'x-space-id': 'test-space',
+        },
+      });
+      await assertFailsWithStatus(400, () => security.authorize(request));
+    });
+
+    it('rejects non-bearer authorization header', async () => {
+      const request = createRequest('test-space', token);
+      request.headers.set('authorization', 'basic YWRtaW46YWRtaW4=');
+      await assertFailsWithStatus(401, () => security.authorize(request));
+    });
+
+    it('rejects malformed bearer token', async () => {
+      const request = createRequest('test-space', 'somestringthatsnotatoken');
+      await assertFailsWithStatus(401, () => security.authorize(request));
+    });
+
+    it('rejects tokens from other issuers', async () => {
+      const security2 = new LocalKeySecurity();
+      const token2 = await security2.generateToken({
+        spaceId: 'test-space',
+        generator: 'unittest',
+        roleKeys: ['test-role'],
+      });
+      const request = createRequest('test-space', token2);
+      await assertFailsWithStatus(401, () => security.authorize(request));
+    });
+
+    it('can authorize request', async () => {
+      await security.authorize(createRequest('test-space', token));
+    });
+  });
+
+  describe('authentication', () => {
+    let tenant1Token;
+    let tenant1AdminToken;
+    let tenant2Token;
+    const security = new LocalKeySecurity();
+    before(async () => {
+      security.roleToPermissions.user = ['app.read'];
+      security.roleToPermissions.admin = ['app.*'];
+      tenant1Token = await security.generateToken({
+        spaceId: 'test-space',
+        generator: 'unittest',
+        roleKeys: ['user'],
+      });
+      assert.ok(tenant1Token);
+      tenant1AdminToken = await security.generateToken({
+        spaceId: 'test-space',
+        generator: 'unittest',
+        roleKeys: ['admin'],
+      });
+      assert.ok(tenant1AdminToken);
+      tenant2Token = await security.generateToken({
+        spaceId: 'test-space2',
+        generator: 'unittest',
+        roleKeys: ['admin'],
+      });
+      assert.ok(tenant2Token);
+    });
+
+    it('allows tenant with no role or permission checks', async () => {
+      await security.authenticate(createRequest('test-space', tenant1Token));
+      await security.authenticate(
+        createRequest('test-space', tenant1AdminToken),
+      );
+    });
+
+    it('disallows cross tenant requests', async () => {
+      const request = createRequest('test-space', tenant2Token);
+      await assertFailsWithStatus(403, () => security.authenticate(request));
+    });
+
+    describe('roles', () => {
+      it('allows with any allowed role', async () => {
+        const request = createRequest('test-space', tenant1AdminToken);
+        await security.authenticate(request, {
+          allowedRoles: ['admin', 'testuser'],
+        });
+      });
+
+      it('disallows without any role', async () => {
+        const request = createRequest('test-space', tenant1Token);
+        await assertFailsWithStatus(403, () => security.authenticate(request, { allowedRoles: ['admin'] }));
+      });
+
+      it('disallows without role AND permissions', async () => {
+        const request = createRequest('test-space', tenant1Token);
+        await assertFailsWithStatus(403, () => security.authenticate(request, { allowedRoles: ['admin'], allowedPermissions: ['app.read'] }));
+      });
+    });
+
+    describe('permissions', () => {
+      it('allows with any permission', async () => {
+        const request = createRequest('test-space', tenant1Token);
+        await security.authenticate(request, {
+          allowedPermissions: ['app.write', 'app.read'],
+        });
+      });
+
+      it('allows with globbed permission', async () => {
+        const request = createRequest('test-space', tenant1AdminToken);
+        security.authenticate(request, {
+          allowedPermissions: ['app.write', 'app.read'],
+        });
+      });
+
+      it('disallowed with globbed permission', async () => {
+        const request = createRequest('test-space', tenant1Token);
+        security.authenticate(request, {
+          allowedPermissions: ['app.write', 'app.read'],
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

https://trello.com/c/2A4zpMbE/250-create-commons-library-for-creating-verifying-frontegg-backend-tokens

Notes:

 - This includes breaking changes to the SecretsManager and the Router
 - SecretsManager changes: improving the structure of the secrets to better allow for identifying / managing secrets by making the pattern:
   [scope:test,prod]/group:companyId,shared]/[application]/[key]
 - Router - changed the parameters passed to the handler to have the params be the first and an info object containing the request and context as the second. The impetus being that generally you already have the context and request available and in _most_ case I was ignoring these params which made for clunky code
 - This implementation is pretty naive -- we probably should put some caching in place
 - The code for checking roles / permissions doesn't quite work for M2M tokens as there's a different method that we're supposed to use, but it doesn't work the way described in Frontegg's docs (but that's not essential now anyway because the scope of this isn't M2M tokens)

Thanks for contributing!
