### PR TITLE
feat: add central function for determining mimetype from ingestion job; algolia script to change mimetypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/content-lake-commons",
-  "version": "1.5.1",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/content-lake-commons",
-      "version": "1.5.1",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.299.0",
@@ -17,6 +17,7 @@
         "clone": "^2.1.2",
         "fetch-retry": "^5.0.4",
         "jsonschema": "^1.4.1",
+        "mime": "^3.0.0",
         "node-fetch": "^3.3.1",
         "routington": "^1.0.3"
       },
@@ -6941,7 +6942,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -18778,8 +18778,7 @@
     "mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
     },
     "mimic-fn": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "clone": "^2.1.2",
     "fetch-retry": "^5.0.4",
     "jsonschema": "^1.4.1",
+    "mime": "^3.0.0",
     "node-fetch": "^3.3.1",
     "routington": "^1.0.3"
   }

--- a/scripts/change-mimetype-index.js
+++ b/scripts/change-mimetype-index.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable no-console */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import dotenv from 'dotenv';
+import { CloudSearchIndexStorage } from '../src/cloud-search-index-storage.js';
+
+dotenv.config();
+
+const context = {
+  env: {
+    ALGOLIA_APP_NAME: process.env.ALGOLIA_APP_NAME,
+    ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
+    ALGOLIA_CI_INDEX: process.env.ALGOLIA_CI_INDEX,
+  },
+  log: console,
+};
+const searchIndexStorage = new CloudSearchIndexStorage(context);
+
+const objects = await searchIndexStorage.getObjectsBy('sourceMimeType', 'application/octet-stream');
+console.log(`Found ${objects.length} assets with sourceMimeType:"application/octet-stream"`);
+
+// if more than 1k entries, run a couple of times
+// TODO: add pagination
+// update the mimetype to application/pdf
+if (objects.length > 0) {
+  console.log(`Updating ${objects.length} assets with sourceMimeType:"application/octet-stream" to application/pdf`);
+  const newObjects = objects.map((doc) => ({ ...doc, sourceMimeType: 'application/pdf' }));
+  await searchIndexStorage.update(newObjects);
+}

--- a/src/cloud-search-index-storage.js
+++ b/src/cloud-search-index-storage.js
@@ -156,17 +156,42 @@ export class CloudSearchIndexStorage {
    * @returns {Promise<Array<string>>} list of objectIDs
    */
   async getObjectIdsByContentHash(contentHash) {
+    return this.getObjectIdsBy('contentHash', contentHash);
+  }
+
+  /**
+   * Get a list of ObjectIDs that contain the key,value pair
+   * Ex: `getObjectIdsBy('sourceType', 's3')` will get all records with `sourceType` of `s3`
+   *
+   * @param {String} key attribute to get by.
+   * @param {String} value value of the attribute to get by.
+   */
+  async getObjectIdsBy(key, value) {
+    const hits = await this.getObjectsBy(key, value);
+    if (hits.length > 0) {
+      return hits.map((hit) => hit.objectID);
+    }
+    return [];
+  }
+  /**
+   * Get a list of ObjectIDs that contain the key,value pair
+   * Ex: `getObjectIdsBy('sourceType', 's3')` will get all records with `sourceType` of `s3`
+   *
+   * @param {String} key attribute to get by.
+   * @param {String} value value of the attribute to get by.
+   */
+  async getObjectsBy(key, value) {
     const searchResult = await this.#index.search(
       '',
       {
         distinct: false,
         facetFilters: [
-          `contentHash:${contentHash}`,
+          `${key}:${value}`,
         ],
       },
     );
     if (searchResult?.nbHits > 0) {
-      return searchResult?.hits.map((hit) => hit.objectID);
+      return searchResult?.hits;
     }
     return [];
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,3 +22,4 @@ export * from './schema-validator.js';
 export * from './secret.js';
 export { CloudSearchIndexStorage } from './cloud-search-index-storage.js';
 export * as mocks from './mocks/index.js';
+export * from './mimetype.js';

--- a/src/mimetype.js
+++ b/src/mimetype.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import path from 'path';
+import Mime from 'mime';
+
+/**
+ * Get mime type from Ingestion Job: either from job.data.name or job.data.mimeType
+ * @param {Object} job Ingestion Job object (TODO: should be its own class)
+ * @returns mime type
+ */
+export function getMimeType(job) {
+  let mime;
+  if (job?.data?.name) {
+    const ext = (path.extname(job.data.name).substring(1)).toLowerCase();
+    if (ext === 'ai') {
+      // special case since mime libraries set this to `application/postscript`
+      mime = 'application/vnd.adobe.illustrator';
+    } else {
+      mime = Mime.getType(ext);
+    }
+  }
+  return mime || job?.data?.mimeType || 'application/octet-stream';
+}

--- a/src/mimetype.js
+++ b/src/mimetype.js
@@ -14,13 +14,15 @@ import path from 'path';
 import Mime from 'mime';
 
 /**
- * Get mime type from Ingestion Job: either from job.data.name or job.data.mimeType
+ * Get mime type from Ingestion Job: either from job.data.mimeType or job.data.name
  * @param {Object} job Ingestion Job object (TODO: should be its own class)
  * @returns mime type
  */
 export function getMimeType(job) {
   let mime;
-  if (job?.data?.name) {
+  if (job?.data?.mimeType) {
+    mime = job.data.mimeType;
+  } else if (job?.data?.name) {
     const ext = (path.extname(job.data.name).substring(1)).toLowerCase();
     if (ext === 'ai') {
       // special case since mime libraries set this to `application/postscript`
@@ -29,5 +31,5 @@ export function getMimeType(job) {
       mime = Mime.getType(ext);
     }
   }
-  return mime || job?.data?.mimeType || 'application/octet-stream';
+  return mime || 'application/octet-stream';
 }

--- a/test/cloud-search-index-storage.test.js
+++ b/test/cloud-search-index-storage.test.js
@@ -172,7 +172,7 @@ describe('Cloud Search Index Storage tests', async () => {
     const saveResult = await searchIndexStorage.save(contentRecord);
     assert.notEqual(undefined, saveResult);
 
-    const objects = await searchIndexStorage.getObjectsBy('sourceType', contentRecord.sourceType);
+    const objects = await searchIndexStorage.getObjectsBy('sourceId', contentRecord.sourceId);
     assert.strictEqual(objects.length, 1);
     assert.deepStrictEqual(objects[0], saveResult);
   });
@@ -181,7 +181,7 @@ describe('Cloud Search Index Storage tests', async () => {
     const saveResult = await searchIndexStorage.save(contentRecord);
     assert.notEqual(undefined, saveResult);
 
-    const objects = await searchIndexStorage.getObjectIdsBy('sourceType', contentRecord.sourceType);
+    const objects = await searchIndexStorage.getObjectIdsBy('sourceId', contentRecord.sourceId);
     assert.strictEqual(objects.length, 1);
     assert.deepStrictEqual(objects[0], saveResult.objectID);
   });

--- a/test/cloud-search-index-storage.test.js
+++ b/test/cloud-search-index-storage.test.js
@@ -167,6 +167,24 @@ describe('Cloud Search Index Storage tests', async () => {
     assert.ok(!hits[0].randomField);
   });
 
+  it('Get all objects by key value pair', async () => {
+    const contentRecord = generateContentRecord();
+    const saveResult = await searchIndexStorage.save(contentRecord);
+    assert.notEqual(undefined, saveResult);
+
+    const objects = await searchIndexStorage.getObjectsBy('sourceType', contentRecord.sourceType);
+    assert.strictEqual(objects.length, 1);
+    assert.deepStrictEqual(objects[0], saveResult);
+  });
+  it('Get all objectIDs by key value pair', async () => {
+    const contentRecord = generateContentRecord();
+    const saveResult = await searchIndexStorage.save(contentRecord);
+    assert.notEqual(undefined, saveResult);
+
+    const objects = await searchIndexStorage.getObjectIdsBy('sourceType', contentRecord.sourceType);
+    assert.strictEqual(objects.length, 1);
+    assert.deepStrictEqual(objects[0], saveResult.objectID);
+  });
   it('Get all objectIDs by contentHash', async () => {
     const contentRecord = generateContentRecord();
     const saveResult = await searchIndexStorage.save(contentRecord);

--- a/test/mimetype.test.js
+++ b/test/mimetype.test.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+
+import assert from 'assert';
+import { getMimeType } from '../src/mimetype.js';
+
+describe('mimetype', () => {
+  it('can get mimetype from extension', () => {
+    const job = {
+      data: {
+        name: 'test.jpg',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'image/jpeg');
+  });
+  it('can get mimetype from mimetype being passed in directly', () => {
+    const job = {
+      data: {
+        mimeType: 'image/jpeg',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'image/jpeg');
+  });
+  it('will prefer mimetype via extension over directly passing it in', () => {
+    const job = {
+      data: {
+        mimeType: 'image/png',
+        name: 'file.jpeg',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'image/jpeg');
+  });
+  it('special mimetype for illustrator files', () => {
+    const job = {
+      data: {
+        name: 'file.ai',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/vnd.adobe.illustrator');
+  });
+  it('gets mimetype for psd files', () => {
+    const job = {
+      data: {
+        name: 'file.psd',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'image/vnd.adobe.photoshop');
+  });
+  it('gets mimetype for pdf files', () => {
+    const job = {
+      data: {
+        name: 'file.pdf',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/pdf');
+  });
+  it('default to `application/octet-stream` if no valid extension', () => {
+    const job = {
+      data: {
+        name: 'file.invalid',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/octet-stream');
+  });
+  it('default to `application/octet-stream` if no file name or mimetype passed in the job object', () => {
+    const job = {
+      file: 'file.jpg',
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/octet-stream');
+  });
+});

--- a/test/mimetype.test.js
+++ b/test/mimetype.test.js
@@ -33,7 +33,22 @@ describe('mimetype', () => {
     const mimeType = getMimeType(job);
     assert.strictEqual(mimeType, 'image/jpeg');
   });
-  it('will prefer mimetype via extension over directly passing it in', () => {
+  it('must be exactly job.data.mimeType', () => {
+    let job = {
+      data: {
+        mimetype: 'image/jpeg',
+      },
+    };
+    let mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/octet-stream');
+
+    job = {
+      mimeType: 'image/jpeg',
+    };
+    mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'application/octet-stream');
+  });
+  it('will prefer mimetype via directly passing it in over extension', () => {
     const job = {
       data: {
         mimeType: 'image/png',
@@ -41,7 +56,7 @@ describe('mimetype', () => {
       },
     };
     const mimeType = getMimeType(job);
-    assert.strictEqual(mimeType, 'image/jpeg');
+    assert.strictEqual(mimeType, 'image/png');
   });
   it('special mimetype for illustrator files', () => {
     const job = {


### PR DESCRIPTION
## Centralize method to get mimetype across lambda's
- ingestor uses this method to get mimetype: https://github.com/adobe/content-lake-ingestor-service/blob/main/src/utils.js#L21-L41
- ingestor dispatcher uses this method: https://github.com/adobe/content-lake-ingestor-dispatcher-service/blob/main/src/indexhandler.js#L24-L41
- this mismatch led to pdf's entering the index as `application/octet-stream`, which i corrected with the script


related ticket: https://trello.com/c/ow3odcpt/273-revisit-supported-mimetypes-in-ingestor

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
