### PR TITLE
chore: Add test for getting SVG MIME type

### DIFF
--- a/test/mimetype.test.js
+++ b/test/mimetype.test.js
@@ -85,6 +85,15 @@ describe('mimetype', () => {
     const mimeType = getMimeType(job);
     assert.strictEqual(mimeType, 'application/pdf');
   });
+  it('gets mimetype for SVG images', () => {
+    const job = {
+      data: {
+        name: 'file.svg',
+      },
+    };
+    const mimeType = getMimeType(job);
+    assert.strictEqual(mimeType, 'image/svg+xml');
+  });
   it('default to `application/octet-stream` if no valid extension', () => {
     const job = {
       data: {


### PR DESCRIPTION
SVG files are fairly common in websites.  We want to add SVG to support website crawler asset ingestion.  `sharp.js` can convert SVGs so this should be a fairly trivial change.

Trello:  https://trello.com/c/ldpWR4tk
